### PR TITLE
Use 2021-september release tag in _config.yaml

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -10,7 +10,7 @@ start_date: 2021-09-20
 end_date: 2021-09-24
 # Specific release in AlexsLemonade/training-modules
 # We use master to make development easier
-release_tag: master
+release_tag: 2021-september
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
 docker_repo: DOCKER-REPOSITORY


### PR DESCRIPTION
Closes #8. The release for this workshop can be found here: https://github.com/AlexsLemonade/training-modules/releases/tag/2021-september