### PR TITLE
Fix some relative links on home page

### DIFF
--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -19,18 +19,18 @@ The Childhood Cancer Data Lab is an initiative of <b><a href="https://www.alexsl
 <h3>Pre-workshop Prep</h3>
 
 <ul>
-<li> Please review the <a href="../code-of-conduct.html" title="Code of Conduct">Code of Conduct</a>.</li>
-<li> If you are new to using R, we've <a href="../optional-workshop-prep/R-prep.html#pre-workshop-prep-for-r-programming" title="assembled some resources for getting starting with R">assembled some resources for getting starting with R</a> that can optionally help prepare you for the workshop.</li>
+<li> Please review the <a href="code-of-conduct.html" title="Code of Conduct">Code of Conduct</a>.</li>
+<li> If you are new to using R, we've <a href="optional-workshop-prep/R-prep.html#pre-workshop-prep-for-r-programming" title="assembled some resources for getting starting with R">assembled some resources for getting starting with R</a> that can optionally help prepare you for the workshop.</li>
 <li> Please install the <a href="workshop/software-setup.html" title="required software">required software</a> and take a look at how we intend to use during the workshop (see below).</li>
 <li> Sign up for the <b>Cancer Data Science</b> Slack workspace at <a href="http://ccdatalab.org/slack" title="http://ccdatalab.org/slack">http://ccdatalab.org/slack</a>. Please use your full name in your profile, so we can find you easily and add you to the private meeting channel.</li>
-<li> Once you have been given your username and temporary password, follow <a href="../virtual-setup/rstudio-login.html" title="these instructions">these instructions</a> to log in to our RStudio server and change your password.</li>
+<li> Once you have been given your username and temporary password, follow <a href="virtual-setup/rstudio-login.html" title="these instructions">these instructions</a> to log in to our RStudio server and change your password.</li>
 </ul>
 
 <p>Please take a look at our procedures to familiarize yourself with how we will be using these platforms throughout training:
 
 <ul>
-<li> <a href="../virtual-setup/zoom-procedures.html" title="Zoom procedures">Zoom procedures</a></li>
-<li> <a href="../virtual-setup/slack-procedures.html" title="Slack procedures">Slack procedures</a></li>
+<li> <a href="virtual-setup/zoom-procedures.html" title="Zoom procedures">Zoom procedures</a></li>
+<li> <a href="virtual-setup/slack-procedures.html" title="Slack procedures">Slack procedures</a></li>
 </ul>
 
 <h2>Schedule</h2>
@@ -43,7 +43,7 @@ The Childhood Cancer Data Lab is an initiative of <b><a href="https://www.alexsl
 
 <p>A description of our plans and goals for the workshop can be found on the <a href="workshop/workshop-structure.html" title="Workshop Structure document">Workshop Structure document</a>. Please also refer to the <a href="workshop/SCHEDULE.html" title="schedule">schedule</a> for information about timing and links relevant to each day. An overview of the modules we will cover and associated links can be found on the <a href="workshop/workshop-materials.html" title="Workshop Materials document">Workshop Materials document</a>.
 
-<p>During instruction sessions, CCDL staff will lead you through course material using <a href="../virtual-setup/zoom-procedures.html" title="Zoom procedures">Zoom procedures</a>, <a href="../virtual-setup/slack-procedures.html" title="Slack procedures">Slack procedures</a>, and <a href="../virtual-setup/rstudio-login.html" title="RStudio Server">RStudio Server</a>. We will record instruction and provide it to workshop attendees so they can revisit it outside of workshop hours or in case they experience disruptions during live instruction.
+<p>During instruction sessions, CCDL staff will lead you through course material using <a href="virtual-setup/zoom-procedures.html" title="Zoom procedures">Zoom procedures</a>, <a href="virtual-setup/slack-procedures.html" title="Slack procedures">Slack procedures</a>, and <a href="virtual-setup/rstudio-login.html" title="RStudio Server">RStudio Server</a>. We will record instruction and provide it to workshop attendees so they can revisit it outside of workshop hours or in case they experience disruptions during live instruction.
 
 <p>During <a href="workshop/resources-for-consultation-sessions.html" title="consultation sessions">consultation sessions</a>, CCDL staff will be available to answer questions and provide 1:1 assistance as you work through exercise notebooks we provide or work with your own transcriptomic data. We’ll use Zoom and Slack for these days, too.
 

--- a/workshop/posting-errors-guidelines.md
+++ b/workshop/posting-errors-guidelines.md
@@ -6,7 +6,7 @@ nav_title: Posting an Error
 <p style="margin-top: 20px;"> </p>
 <p>We use the <b>Cancer Data Science Slack</b> team administered by the CCDL for communication.
 If you haven't joined Cancer Data Science Slack yet, you will need to follow the 
-<a href="https://alexslemonade.github.io/{{site.repository}}/virtual-setup/slack-procedures.md">
+<a href="https://alexslemonade.github.io/{{site.repository}}/virtual-setup/slack-procedures.html">
 set up procedures described here</a>.</p>
 <br>
 During and after the workshop, we encourage you to post your code error question to your Slack training channel.


### PR DESCRIPTION
Looked into this because of https://github.com/AlexsLemonade/2021-september-training/pull/20#pullrequestreview-754315843

As far as I can tell, these broke when we moved to HTML formatting in #14 because the 2021 June website works okay. Built locally and I believe I checked all links.