### PR TITLE
Update `_config.yaml` to use values relevant to the workshop

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -13,17 +13,8 @@ end_date: 2021-09-24
 release_tag: 2021-september
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
-docker_repo: DOCKER-REPOSITORY
-docker_tag: DOCKER-TAG
-# These are for loading Docker images from a file; only relevant for in-person
-docker_targz: ccdl_docker_image.tar.gz
-docker_tar: ccdl_docker_image.tar
-# The image ID and size can be obtained by running `docker images` once you have a copy of the correct image for the training
-docker_image_id: IMAGEID
-docker_size: SIZE
-# How we have historically distributed materials in-person
-training_zip: TRAINING-ZIP
-training_unzip_folder: TRAINING-UNZIP-FOLDER
+docker_repo: training_rnaseq
+docker_tag: 2021-september
 
 # Theme and theme options
 theme: minima


### PR DESCRIPTION
Closes #4 

This PR updates the `_config.yaml` file to use the relevant docker associated values for this workshop (as set in https://github.com/AlexsLemonade/training-admin/issues/555).  I also removed all of the variables that are specific to in person workshops.

Please let me know if I missed anything that should be updated or removed anything that should be included.